### PR TITLE
CEA-2294: Fix reverse tabnabbing vulnerability in Quill

### DIFF
--- a/dist/quill.js
+++ b/dist/quill.js
@@ -8982,7 +8982,7 @@ LinkTooltip = (function(superClass) {
 
   LinkTooltip.DEFAULTS = {
     maxLength: 50,
-    template: '<span class="title">Visit URL:&nbsp;</span> <a href="#" class="url" target="_blank" href="about:blank"></a> <input class="input" type="text"> <span>&nbsp;&#45;&nbsp;</span> <a href="javascript:;" class="change">Change</a> <a href="javascript:;" class="remove">Remove</a> <a href="javascript:;" class="done">Done</a>'
+    template: '<span class="title">Visit URL:&nbsp;</span> <a href="#" class="url" rel="noopener" target="_blank" href="about:blank"></a> <input class="input" type="text"> <span>&nbsp;&#45;&nbsp;</span> <a href="javascript:;" class="change">Change</a> <a href="javascript:;" class="remove">Remove</a> <a href="javascript:;" class="done">Done</a>'
   };
 
   LinkTooltip.hotkeys = {

--- a/src/modules/link-tooltip.coffee
+++ b/src/modules/link-tooltip.coffee
@@ -8,7 +8,7 @@ class LinkTooltip extends Tooltip
     maxLength: 50
     template:
      '<span class="title">Visit URL:&nbsp;</span>
-      <a href="#" class="url" target="_blank" href="about:blank"></a>
+      <a href="#" class="url" target="_blank" rel="noopener" href="about:blank"></a>
       <input class="input" type="text">
       <span>&nbsp;&#45;&nbsp;</span>
       <a href="javascript:;" class="change">Change</a>


### PR DESCRIPTION
[CEA-2294](https://outreach-io.atlassian.net/browse/CEA-2294)

This fixes the reverse tabnabbing vulnerability discovered during a recent security audit. This only applies to links opened via Quill since it opens them in a new tab from the LinkTooltip. Links clicked in viewed emails from the app aren't susceptible to the vulnerability since they open in the same tab.